### PR TITLE
Fixes 'warning: ::Fixnum is deprecated' for ruby 2.4+

### DIFF
--- a/lib/libcbor.rb
+++ b/lib/libcbor.rb
@@ -27,7 +27,7 @@ module CBOR
 	# Custom semantics are supported - the object has to to provide the +to_cbor+ method
 	# In case {CBOR.method_name} is not +to_cbor+, provide the custom method instead.
 	#
-	# @param [Fixnum, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass, #to_cbor] object the object to encode
+	# @param [Integer, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass, #to_cbor] object the object to encode
 	# @return [String] the CBOR representation
 	def self.encode(object)
 		object.to_cbor
@@ -46,7 +46,7 @@ module CBOR
 	# @return [Array] list of the patched classes
 	def self.load!(name = nil)
 		@@method_name = name || :to_cbor
-		%w{Fixnum Float Array Hash String TrueClass FalseClass NilClass Tag ByteString}.each do |klass|
+		%w{Integer Float Array Hash String TrueClass FalseClass NilClass Tag ByteString}.each do |klass|
 			kklass = const_get(klass)
 			kklass.send(:include, const_get('::CBOR::' + klass + 'Helper'))
 			kklass.send(:alias_method, method_name, :__libcbor_to_cbor)
@@ -56,7 +56,7 @@ module CBOR
 	# Deserialize CBOR
 	#
 	# @param [String] data
-	# @return [Fixnum, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass] resulting object
+	# @return [Integer, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass] resulting object
 	# @raise [DecodingError] when presented with invalid data
 	def self.decode(data)
 		res = FFI::MemoryPointer.new LibCBOR::CborLoadResult

--- a/lib/libcbor/helpers.rb
+++ b/lib/libcbor/helpers.rb
@@ -1,7 +1,7 @@
 module CBOR
-	# Provides the {#to_cbor} (or equivalent) method for Fixnums
-	module FixnumHelper
-		# Encodes Fixnums. Width and signedness are handled automatically.
+	# Provides the {#to_cbor} (or equivalent) method for Integers
+	module IntegerHelper
+		# Encodes Integers. Width and signedness are handled automatically.
 		#
 		# @return [String] The CBOR representation
 		def __libcbor_to_cbor

--- a/lib/libcbor/item.rb
+++ b/lib/libcbor/item.rb
@@ -17,7 +17,7 @@ module CBOR
 		#
 		# Arrays and hash maps are constructed recursively
 		#
-		# @return [Fixnum, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass] Value extracted from the {#handle}
+		# @return [Integer, String, Float, Array, Map, Tag, TrueClass, FalseClass, NilClass] Value extracted from the {#handle}
 		def value
 			case type
 				when :uint

--- a/lib/libcbor/streaming/buffered_decoder.rb
+++ b/lib/libcbor/streaming/buffered_decoder.rb
@@ -7,20 +7,20 @@ module CBOR
 		# an example
 		class BufferedDecoder
 			# @param [Hash] callbacks the callbacks to invoke during parsing.
-			# @option callbacks [Proc<Fixnum>] :integer Integers, both positive and negative
+			# @option callbacks [Proc<Integer>] :integer Integers, both positive and negative
 			# @option callbacks [Proc<String>] :string Definite string
 			# @option callbacks [Proc] :chunked_string_start Chunked string. Chunks follow
 			# @option callbacks [Proc<String>] :byte_string Definite byte string
 			# @option callbacks [Proc] :chunked_byte_string_start Chunked byte string. Chunks follow
 			# @option callbacks [Proc<Float>] :float Float
-			# @option callbacks [Proc<length: Fixnum>] :definite_array Definite array
+			# @option callbacks [Proc<length: Integer>] :definite_array Definite array
 			# @option callbacks [Proc] :array_start Indefinite array start
-			# @option callbacks [Proc<length: Fixnum>] :definite_map Definite map. Length pairs follow
+			# @option callbacks [Proc<length: Integer>] :definite_map Definite map. Length pairs follow
 			# @option callbacks [Proc] :map_start Indefinite map start
-			# @option callbacks [Proc<value: Fixnum>] :tag Tag. Tagged item follows
+			# @option callbacks [Proc<value: Integer>] :tag Tag. Tagged item follows
 			# @option callbacks [Proc<Bool>] :bool Boolean
 			# @option callbacks [Proc] :null Null
-			# @option callbacks [Proc<value: Fixnum>] :simple Simple value other than +true, false, nil+
+			# @option callbacks [Proc<value: Integer>] :simple Simple value other than +true, false, nil+
 			# @option callbacks [Proc] :break Indefinite item break
 			def initialize(callbacks = {})
 				@callbacks = {

--- a/lib/libcbor/streaming/encoder.rb
+++ b/lib/libcbor/streaming/encoder.rb
@@ -55,7 +55,7 @@ module CBOR
 			# You are responsible for correctly supplying the item that
 			# follows (i.e. the one the tag will apply to)
 			#
-			# @param [Fixnum] value Tag value.
+			# @param [Integer] value Tag value.
 			# @return [void]
 			def tag(value)
 				@@bfr ||= FFI::Buffer.new(:uchar, 9)

--- a/lib/libcbor/tag.rb
+++ b/lib/libcbor/tag.rb
@@ -1,7 +1,7 @@
 module CBOR
 	# Represents a tagged item -- a pair of number and the item
 	#
-	# @attr [Fixnum] value The tag value
+	# @attr [Integer] value The tag value
 	# @attr [Object] item The tagged item
 	class Tag < Struct.new(:value, :item)
 		def ==(other)

--- a/spec/encoding_spec.rb
+++ b/spec/encoding_spec.rb
@@ -4,7 +4,7 @@ module CBOR
 	describe 'Encoding' do
 		before(:all) { CBOR.load! }
 
-		describe Fixnum do
+		describe Integer do
 			it 'returns correct bytes' do
 				expect(2.to_cbor).to eq "\x02"
 				expect(-2.to_cbor).to eq "\x21"


### PR DESCRIPTION
Fixes warning `warning: constant ::Fixnum is deprecated` for ruby 2.4+`